### PR TITLE
[#4] 회원가입

### DIFF
--- a/src/main/java/com/earseo/member/common/config/SecurityConfig.java
+++ b/src/main/java/com/earseo/member/common/config/SecurityConfig.java
@@ -1,0 +1,46 @@
+package com.earseo.member.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+//    @Bean
+//    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+//        http
+//                .csrf(AbstractHttpConfigurer::disable)
+//                .httpBasic(AbstractHttpConfigurer::disable)
+//                .formLogin(AbstractHttpConfigurer::disable)
+//                .sessionManagement(session -> session
+//                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+//
+//        http
+//                .authorizeHttpRequests(authorize -> authorize
+//                        // GUEST
+//                        .requestMatchers("/api/member/**").permitAll()
+//                        // Swagger
+//                        .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
+//                        // USER
+//                        .requestMatchers("/api/user/member/**").authenticated()
+//                        // ADMIN
+//                        .requestMatchers("/api/admin/member/**").hasRole("ADMIN")
+//                        .anyRequest().authenticated()
+//                );
+//
+//        return http.build();
+//    }
+}

--- a/src/main/java/com/earseo/member/common/exception/MemberErrorCode.java
+++ b/src/main/java/com/earseo/member/common/exception/MemberErrorCode.java
@@ -12,7 +12,7 @@ public enum MemberErrorCode implements ErrorCodeInterface {
     DUPLICATE_EMAIL("MBR002", "이미 사용중인 이메일입니다.", HttpStatus.CONFLICT),
     INVALID_PASSWORD("MBR003", "비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     INVALID_CREDENTIALS("MBR004", "이메일 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
-    MEMBER_ALREADY_EXISTS("MBR005", "이미 가입된 회원입니다.", HttpStatus.CONFLICT),
+    MEMBER_ALREADY_EXISTS("MBR005", "이미 가입된 회원 또는 사용 중인 닉네임입니다.", HttpStatus.CONFLICT),
     UNAUTHORIZED_ACCESS("MBR006", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN);
 
     private final String status;

--- a/src/main/java/com/earseo/member/controller/MemberController.java
+++ b/src/main/java/com/earseo/member/controller/MemberController.java
@@ -1,0 +1,29 @@
+package com.earseo.member.controller;
+
+import com.earseo.member.common.BaseResponse;
+import com.earseo.member.dto.request.SignUpRequestDto;
+import com.earseo.member.dto.response.SignUpResponseDto;
+import com.earseo.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/member")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+
+    @Operation(summary = "회원가입", description = "이메일/비밀번호 기반 회원가입")
+    @PostMapping("/signup")
+    public ResponseEntity<BaseResponse<SignUpResponseDto>> signup(
+            @Valid @RequestBody SignUpRequestDto request) {
+        SignUpResponseDto response = memberService.signup(request);
+        return ResponseEntity.ok(BaseResponse.ok(response));
+    }
+}

--- a/src/main/java/com/earseo/member/dto/request/SignUpRequestDto.java
+++ b/src/main/java/com/earseo/member/dto/request/SignUpRequestDto.java
@@ -1,0 +1,27 @@
+package com.earseo.member.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record SignUpRequestDto(
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+        String password,
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 50, message = "닉네임은 2자 이상 50자 이하여야 합니다.")
+        String nickname,
+
+        String gender,
+        LocalDate birthdate,
+        String nationality
+) {
+}

--- a/src/main/java/com/earseo/member/dto/response/SignUpResponseDto.java
+++ b/src/main/java/com/earseo/member/dto/response/SignUpResponseDto.java
@@ -1,0 +1,11 @@
+package com.earseo.member.dto.response;
+
+import com.earseo.member.entity.Role;
+
+public record SignUpResponseDto(
+        Long memberId,
+        String email,
+        String nickname,
+        Role role
+) {
+}

--- a/src/main/java/com/earseo/member/entity/Member.java
+++ b/src/main/java/com/earseo/member/entity/Member.java
@@ -31,7 +31,7 @@ public class Member extends BaseEntity{
     @Column(nullable = false)
     private Provider provider;
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 50, nullable = false, unique = true)
     private String nickname;
 
     @Column(length = 255)

--- a/src/main/java/com/earseo/member/entity/Member.java
+++ b/src/main/java/com/earseo/member/entity/Member.java
@@ -6,7 +6,7 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "member")
+@Table(name = "member", schema = "member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/earseo/member/repository/MemberRepository.java
+++ b/src/main/java/com/earseo/member/repository/MemberRepository.java
@@ -1,0 +1,18 @@
+package com.earseo.member.repository;
+
+import com.earseo.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    // 이메일로 회원 조회
+    Optional<Member> findByEmail(String email);
+
+    // 이메일 중복 확인
+    boolean existsByEmail(String email);
+
+    // 닉네임 중복 확인
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/earseo/member/service/MemberService.java
+++ b/src/main/java/com/earseo/member/service/MemberService.java
@@ -1,0 +1,53 @@
+package com.earseo.member.service;
+
+import com.earseo.member.common.exception.BaseException;
+import com.earseo.member.common.exception.MemberErrorCode;
+import com.earseo.member.dto.request.SignUpRequestDto;
+import com.earseo.member.dto.response.SignUpResponseDto;
+import com.earseo.member.entity.Member;
+import com.earseo.member.entity.Provider;
+import com.earseo.member.entity.Role;
+import com.earseo.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public SignUpResponseDto signup(SignUpRequestDto request) {
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new BaseException(MemberErrorCode.DUPLICATE_EMAIL);
+        }
+
+        if (memberRepository.existsByNickname(request.nickname())) {
+            throw new BaseException(MemberErrorCode.MEMBER_ALREADY_EXISTS);
+        }
+
+        Member member = Member.builder()
+                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
+                .role(Role.USER)
+                .nickname(request.nickname())
+                .gender(request.gender())
+                .birthdate(request.birthdate())
+                .nationality(request.nationality())
+                .provider(Provider.LOCAL)
+                .build();
+
+        Member savedMember = memberRepository.save(member);
+
+        return new SignUpResponseDto(
+                savedMember.getMemberId(),
+                savedMember.getEmail(),
+                savedMember.getNickname(),
+                savedMember.getRole()
+        );
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -26,6 +26,7 @@ spring:
         show_sql: true
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_schema: member
     open-in-view: false
 
 #  kafka:


### PR DESCRIPTION
## 🧩 구현/변경 사항
- 이메일/비밀번호 기반 회원가입 기능
- 비밀번호 BCrypt 암호화

---

## 사용자 시나리오(UML)(옵션)

---

## 🧪 테스트 결과
<img width="842" height="674" alt="image" src="https://github.com/user-attachments/assets/9cd30b6f-6ea9-4a78-a5c8-042e3ff84ac5" />

---

## BREAKING CHANGE (옵션)
- <호환성 깨짐 / API 변경 / 클라이언트 수정 필요 사항>
- (예: `/user/{userId}/alert` → `/user/queue/alert` 변경, timestamp 포맷 KST 필수 등)

---

## 참고
- 기타 후속 작업이나 주의사항
- (예: JWT 인증은 추후 연동 예정, 로깅 레벨은 임시 상향 조정 등)

---

## 🪞 회고 및 개선 아이디어 (옵션)
- JWT 갱신 로직은 추후 Refresh Token 구조로 개선 예정
- 이메일 인증 (기본 구현만 해놓고 이메일 인증 코드 관련 개발은 추후에 작성 예정)
- SecurityConfig는 내부 테스트로 남겨놓고 추후에 삭제할 예정입니다

---

## 💬 리뷰 받고 싶은 부분 (옵션)
