### PR TITLE
[#13] 마이페이지 회원정보 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/earseo/member/common/exception/MemberErrorCode.java
+++ b/src/main/java/com/earseo/member/common/exception/MemberErrorCode.java
@@ -14,7 +14,8 @@ public enum MemberErrorCode implements ErrorCodeInterface {
     INVALID_CREDENTIALS("MEM004", "이메일 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
     SOCIAL_MEMBER_CANNOT_CHANGE_PASSWORD("MEM005", "소셜 로그인 회원은 비밀번호를 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
     INVALID_CURRENT_PASSWORD("MEM006", "현재 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
-    PASSWORD_MISMATCH("MEM007", "새 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+    PASSWORD_MISMATCH("MEM007", "새 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_REGISTERED_WITH_DIFFERENT_PROVIDER("MEM008", "이미 다른 방식으로 가입된 이메일입니다.", HttpStatus.CONFLICT);
 
     private final String status;
     private final String message;

--- a/src/main/java/com/earseo/member/common/exception/MemberErrorCode.java
+++ b/src/main/java/com/earseo/member/common/exception/MemberErrorCode.java
@@ -11,7 +11,10 @@ public enum MemberErrorCode implements ErrorCodeInterface {
     MEMBER_NOT_FOUND("MEM001", "회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     DUPLICATE_EMAIL("MEM002", "이미 사용중인 이메일입니다.", HttpStatus.CONFLICT),
     DUPLICATE_NICKNAME("MEM003", "이미 사용중인 닉네임입니다.", HttpStatus.CONFLICT),
-    INVALID_CREDENTIALS("MEM004", "이메일 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED);
+    INVALID_CREDENTIALS("MEM004", "이메일 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    SOCIAL_MEMBER_CANNOT_CHANGE_PASSWORD("MEM005", "소셜 로그인 회원은 비밀번호를 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CURRENT_PASSWORD("MEM006", "현재 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    PASSWORD_MISMATCH("MEM007", "새 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
 
     private final String status;
     private final String message;

--- a/src/main/java/com/earseo/member/controller/AuthController.java
+++ b/src/main/java/com/earseo/member/controller/AuthController.java
@@ -7,7 +7,7 @@ import com.earseo.member.dto.request.SignUpRequestDto;
 import com.earseo.member.dto.response.SocialLoginResponseDto;
 import com.earseo.member.dto.response.LoginResponseDto;
 import com.earseo.member.dto.response.SignUpResponseDto;
-import com.earseo.member.service.MemberService;
+import com.earseo.member.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,19 +18,19 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/member")
 @RequiredArgsConstructor
 public class AuthController {
-    private final MemberService memberService;
+    private final AuthService authService;
 
     @Operation(summary = "회원가입", description = "이메일/비밀번호 기반 회원가입")
     @PostMapping("/signup")
     public ResponseEntity<BaseResponse<SignUpResponseDto>> signup(@Valid @RequestBody SignUpRequestDto request) {
-        SignUpResponseDto response = memberService.signup(request);
+        SignUpResponseDto response = authService.signup(request);
         return ResponseEntity.ok(BaseResponse.ok(response));
     }
 
     @Operation(summary = "로그인", description = "이메일/비밀번호 기반 로그인 및 JWT 토큰 발급")
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<LoginResponseDto>> login(@Valid @RequestBody LoginRequestDto request) {
-        LoginResponseDto response = memberService.login(request);
+        LoginResponseDto response = authService.login(request);
         return ResponseEntity.ok(BaseResponse.ok(response));
     }
 
@@ -38,7 +38,7 @@ public class AuthController {
     @GetMapping("/oauth/google")
     public ResponseEntity<BaseResponse<SocialLoginResponseDto>> googleCallback(
             @RequestParam("code") String code) {
-        SocialLoginResponseDto response = memberService.googleLogin(code);
+        SocialLoginResponseDto response = authService.googleLogin(code);
         return ResponseEntity.ok(BaseResponse.ok(response));
     }
 
@@ -47,7 +47,14 @@ public class AuthController {
     @PostMapping("/oauth/additional-info")
     public ResponseEntity<BaseResponse<LoginResponseDto>> completeSocialSignUp(
             @Valid @RequestBody SocialSignUpRequestDto request) {
-        LoginResponseDto response = memberService.completeSocialSignUp(request);
+        LoginResponseDto response = authService.completeSocialSignUp(request);
         return ResponseEntity.ok(BaseResponse.ok(response));
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃")
+    @PostMapping("/logout")
+    public ResponseEntity<BaseResponse<Void>> logout() {
+        authService.logout();
+        return ResponseEntity.ok(BaseResponse.ok(null));
     }
 }

--- a/src/main/java/com/earseo/member/controller/MemberController.java
+++ b/src/main/java/com/earseo/member/controller/MemberController.java
@@ -1,11 +1,58 @@
 package com.earseo.member.controller;
 
+import com.earseo.member.common.BaseResponse;
+import com.earseo.member.dto.request.PasswordUpdateRequestDto;
+import com.earseo.member.dto.request.ProfileUpdateRequestDto;
+import com.earseo.member.dto.response.ProfileResponseDto;
+import com.earseo.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/user/member")
 @RequiredArgsConstructor
 public class MemberController {
+    private final MemberService memberService;
+
+    @Operation(summary = "프로필 조회", description = "현재 로그인한 회원의 프로필 정보 조회")
+    @GetMapping("/profile")
+    public ResponseEntity<BaseResponse<ProfileResponseDto>> getProfile() {
+        // 추후에 Gateway로 검증 후 헤더에 memberId 전달 (임시로 1L 사용)
+        Long memberId = 1L;
+        ProfileResponseDto response = memberService.getProfile(memberId);
+        return ResponseEntity.ok(BaseResponse.ok(response));
+    }
+
+    @Operation(summary = "프로필 수정", description = "회원 정보 수정 (프로필 사진 제외)")
+    @PutMapping("/profile")
+    public ResponseEntity<BaseResponse<ProfileResponseDto>> updateProfile(
+            @Valid @RequestBody ProfileUpdateRequestDto request) {
+        // 추후에 Gateway로 검증 후 헤더에 memberId 전달 (임시로 1L 사용)
+        Long memberId = 1L;
+        ProfileResponseDto response = memberService.updateProfile(memberId, request);
+        return ResponseEntity.ok(BaseResponse.ok(response));
+    }
+
+    @Operation(summary = "비밀번호 변경", description = "현재 비밀번호 확인 후 새 비밀번호로 변경")
+    @PutMapping("/password")
+    public ResponseEntity<BaseResponse<Void>> updatePassword(
+            @Valid @RequestBody PasswordUpdateRequestDto request) {
+        // 추후에 Gateway로 검증 후 헤더에 memberId 전달 (임시로 1L 사용)
+        Long memberId = 1L;
+        memberService.updatePassword(memberId, request);
+        return ResponseEntity.ok(BaseResponse.ok(null));
+    }
+
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 처리")
+    @DeleteMapping
+    public ResponseEntity<BaseResponse<Void>> deleteMember() {
+        // 추후에 Gateway로 검증 후 헤더에 memberId 전달 (임시로 1L 사용)
+        Long memberId = 1L;
+        memberService.deleteMember(memberId);
+        return ResponseEntity.ok(BaseResponse.ok(null));
+    }
 }

--- a/src/main/java/com/earseo/member/dto/request/PasswordUpdateRequestDto.java
+++ b/src/main/java/com/earseo/member/dto/request/PasswordUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package com.earseo.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record PasswordUpdateRequestDto(
+        @NotBlank(message = "현재 비밀번호는 필수입니다")
+        String currentPassword,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+        String newPassword,
+
+        @NotBlank(message = "비밀번호 확인은 필수입니다")
+        String newPasswordConfirm
+) {
+}

--- a/src/main/java/com/earseo/member/dto/request/ProfileUpdateRequestDto.java
+++ b/src/main/java/com/earseo/member/dto/request/ProfileUpdateRequestDto.java
@@ -1,0 +1,25 @@
+package com.earseo.member.dto.request;
+
+import com.earseo.member.entity.Gender;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record ProfileUpdateRequestDto(
+        @NotBlank(message = "닉네임은 필수입니다")
+        @Size(min = 2, max = 50, message = "닉네임은 2자 이상 50자 이하여야 합니다")
+        String nickname,
+
+        @NotNull(message = "성별은 필수입니다")
+        Gender gender,
+
+        @NotNull(message = "생년월일은 필수입니다")
+        LocalDate birthdate,
+
+        @NotBlank(message = "국적은 필수입니다")
+        @Size(max = 100, message = "국적은 100자 이하여야 합니다")
+        String nationality
+) {
+}

--- a/src/main/java/com/earseo/member/dto/response/ProfileResponseDto.java
+++ b/src/main/java/com/earseo/member/dto/response/ProfileResponseDto.java
@@ -1,0 +1,16 @@
+package com.earseo.member.dto.response;
+
+import com.earseo.member.entity.Gender;
+
+import java.time.LocalDate;
+
+public record ProfileResponseDto(
+        Long memberId,
+        String email,
+        String nickname,
+        String profileImage,
+        Gender gender,
+        LocalDate birthdate,
+        String nationality
+) {
+}

--- a/src/main/java/com/earseo/member/entity/Member.java
+++ b/src/main/java/com/earseo/member/entity/Member.java
@@ -17,7 +17,7 @@ public class Member extends BaseEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
 
-    @Column(length = 100, unique = true)
+    @Column(length = 100, unique = true, nullable = false)
     private String email;
 
     @Enumerated(EnumType.STRING)
@@ -47,5 +47,14 @@ public class Member extends BaseEntity{
     @Column(length = 100)
     private String nationality;
 
+    public void updateProfile(String nickname, Gender gender, LocalDate birthdate, String nationality) {
+        this.nickname = nickname;
+        this.gender = gender;
+        this.birthdate = birthdate;
+        this.nationality = nationality;
+    }
 
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/earseo/member/service/AuthService.java
+++ b/src/main/java/com/earseo/member/service/AuthService.java
@@ -37,9 +37,7 @@ public class AuthService {
 
     @Transactional
     public SignUpResponseDto signup(SignUpRequestDto request) {
-        if (memberRepository.existsByEmail(request.email())) {
-            throw new BaseException(MemberErrorCode.DUPLICATE_EMAIL);
-        }
+        validateDuplicateMember(request.email(), Provider.LOCAL);
 
         if (memberRepository.existsByNickname(request.nickname())) {
             throw new BaseException(MemberErrorCode.DUPLICATE_NICKNAME);
@@ -135,9 +133,7 @@ public class AuthService {
     @Transactional
     public LoginResponseDto completeSocialSignUp(SocialSignUpRequestDto request) {
         // 이미 가입된 회원인지 확인
-        if (memberRepository.findByEmailAndProvider(request.email(), request.provider()).isPresent()) {
-            throw new BaseException(MemberErrorCode.DUPLICATE_EMAIL);
-        }
+        validateDuplicateMember(request.email(), request.provider());
 
         // 닉네임 중복 확인
         if (memberRepository.existsByNickname(request.nickname())) {
@@ -175,4 +171,17 @@ public class AuthService {
     }
 
     public void logout(){}
+
+    private void validateDuplicateMember(String email, Provider provider) {
+        // 같은 이메일, 같은 Provider 확인
+        if (memberRepository.findByEmailAndProvider(email, provider).isPresent()) {
+            throw new BaseException(MemberErrorCode.DUPLICATE_EMAIL);
+        }
+
+        // 같은 이메일로 다른 Provider 가입 여부 확인
+        Optional<Member> existingMember = memberRepository.findByEmail(email);
+        if (existingMember.isPresent()) {
+            throw new BaseException(MemberErrorCode.ALREADY_REGISTERED_WITH_DIFFERENT_PROVIDER);
+        }
+    }
 }

--- a/src/main/java/com/earseo/member/service/AuthService.java
+++ b/src/main/java/com/earseo/member/service/AuthService.java
@@ -1,0 +1,178 @@
+package com.earseo.member.service;
+
+import com.earseo.member.common.exception.BaseException;
+import com.earseo.member.common.exception.MemberErrorCode;
+import com.earseo.member.dto.request.SocialSignUpRequestDto;
+import com.earseo.member.dto.request.LoginRequestDto;
+import com.earseo.member.dto.request.SignUpRequestDto;
+import com.earseo.member.dto.response.SocialLoginResponseDto;
+import com.earseo.member.dto.response.GoogleUserInfoResponse;
+import com.earseo.member.dto.response.LoginResponseDto;
+import com.earseo.member.dto.response.SignUpResponseDto;
+import com.earseo.member.entity.Member;
+import com.earseo.member.entity.Provider;
+import com.earseo.member.entity.Role;
+import com.earseo.member.repository.MemberRepository;
+import com.earseo.member.service.oauth.GoogleOAuthService;
+import com.earseo.member.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+    private final GoogleOAuthService googleOAuthService;
+
+    @Value("${member.default-profile-image}")
+    private String defaultProfileImage;
+
+    @Transactional
+    public SignUpResponseDto signup(SignUpRequestDto request) {
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new BaseException(MemberErrorCode.DUPLICATE_EMAIL);
+        }
+
+        if (memberRepository.existsByNickname(request.nickname())) {
+            throw new BaseException(MemberErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        Member member = Member.builder()
+                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
+                .role(Role.USER)
+                .nickname(request.nickname())
+                .gender(request.gender())
+                .birthdate(request.birthdate())
+                .nationality(request.nationality())
+                .provider(Provider.LOCAL)
+                .profileImage(defaultProfileImage)
+                .build();
+
+        Member savedMember = memberRepository.save(member);
+
+        return new SignUpResponseDto(
+                savedMember.getMemberId(),
+                savedMember.getEmail(),
+                savedMember.getNickname(),
+                savedMember.getRole()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public LoginResponseDto login(LoginRequestDto request) {
+        Member member = memberRepository.findByEmail(request.email())
+                .orElseThrow(()-> new BaseException(MemberErrorCode.INVALID_CREDENTIALS));
+
+        if (!passwordEncoder.matches(request.password(), member.getPassword())) {
+            throw new BaseException(MemberErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String accessToken = jwtUtil.generateAccessToken(
+                member.getMemberId(),
+                member.getEmail(),
+                member.getRole()
+        );
+
+        String refreshToken = jwtUtil.generateRefreshToken(member.getMemberId());
+
+        return new LoginResponseDto(
+                accessToken,
+                refreshToken,
+                member.getMemberId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getRole()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public SocialLoginResponseDto googleLogin(String code) {
+        // 구글에서 사용자 정보 조회
+        var tokenResponse = googleOAuthService.getAccessToken(code);
+        GoogleUserInfoResponse googleUser = googleOAuthService.getUserInfo(tokenResponse.accessToken());
+
+        // DB에서 회원 확인 (email + provider)
+        Optional<Member> memberOpt = memberRepository
+                .findByEmailAndProvider(googleUser.email(), Provider.GOOGLE);
+
+        if (memberOpt.isPresent()) {
+            // 기존 회원 - 로그인 처리
+            Member member = memberOpt.get();
+
+            String accessToken = jwtUtil.generateAccessToken(
+                    member.getMemberId(),
+                    member.getEmail(),
+                    member.getRole()
+            );
+            String refreshToken = jwtUtil.generateRefreshToken(member.getMemberId());
+
+            LoginResponseDto loginResponse = new LoginResponseDto(
+                    accessToken,
+                    refreshToken,
+                    member.getMemberId(),
+                    member.getEmail(),
+                    member.getNickname(),
+                    member.getRole()
+            );
+
+            return SocialLoginResponseDto.existing(loginResponse);
+        } else {
+            // 신규 회원 - 추가 정보 입력 필요
+            return SocialLoginResponseDto.newMember(googleUser.email());
+        }
+    }
+
+
+    @Transactional
+    public LoginResponseDto completeSocialSignUp(SocialSignUpRequestDto request) {
+        // 이미 가입된 회원인지 확인
+        if (memberRepository.findByEmailAndProvider(request.email(), request.provider()).isPresent()) {
+            throw new BaseException(MemberErrorCode.DUPLICATE_EMAIL);
+        }
+
+        // 닉네임 중복 확인
+        if (memberRepository.existsByNickname(request.nickname())) {
+            throw new BaseException(MemberErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        Member member = Member.builder()
+                .email(request.email())
+                .provider(request.provider())
+                .nickname(request.nickname())
+                .gender(request.gender())
+                .birthdate(request.birthdate())
+                .nationality(request.nationality())
+                .role(Role.USER)
+                .profileImage(defaultProfileImage)
+                .build();
+
+        Member savedMember = memberRepository.save(member);
+
+        String accessToken = jwtUtil.generateAccessToken(
+                savedMember.getMemberId(),
+                savedMember.getEmail(),
+                savedMember.getRole()
+        );
+        String refreshToken = jwtUtil.generateRefreshToken(savedMember.getMemberId());
+
+        return new LoginResponseDto(
+                accessToken,
+                refreshToken,
+                savedMember.getMemberId(),
+                savedMember.getEmail(),
+                savedMember.getNickname(),
+                savedMember.getRole()
+        );
+    }
+
+    public void logout(){}
+}

--- a/src/main/java/com/earseo/member/service/MemberService.java
+++ b/src/main/java/com/earseo/member/service/MemberService.java
@@ -2,25 +2,16 @@ package com.earseo.member.service;
 
 import com.earseo.member.common.exception.BaseException;
 import com.earseo.member.common.exception.MemberErrorCode;
-import com.earseo.member.dto.request.SocialSignUpRequestDto;
-import com.earseo.member.dto.request.LoginRequestDto;
-import com.earseo.member.dto.request.SignUpRequestDto;
-import com.earseo.member.dto.response.SocialLoginResponseDto;
-import com.earseo.member.dto.response.GoogleUserInfoResponse;
-import com.earseo.member.dto.response.LoginResponseDto;
-import com.earseo.member.dto.response.SignUpResponseDto;
+import com.earseo.member.dto.request.PasswordUpdateRequestDto;
+import com.earseo.member.dto.request.ProfileUpdateRequestDto;
+import com.earseo.member.dto.response.*;
 import com.earseo.member.entity.Member;
 import com.earseo.member.entity.Provider;
-import com.earseo.member.entity.Role;
 import com.earseo.member.repository.MemberRepository;
-import com.earseo.member.service.oauth.GoogleOAuthService;
-import com.earseo.member.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,143 +19,75 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
-    private final JwtUtil jwtUtil;
-    private final GoogleOAuthService googleOAuthService;
-
-    @Transactional
-    public SignUpResponseDto signup(SignUpRequestDto request) {
-        if (memberRepository.existsByEmail(request.email())) {
-            throw new BaseException(MemberErrorCode.DUPLICATE_EMAIL);
-        }
-
-        if (memberRepository.existsByNickname(request.nickname())) {
-            throw new BaseException(MemberErrorCode.DUPLICATE_NICKNAME);
-        }
-
-        Member member = Member.builder()
-                .email(request.email())
-                .password(passwordEncoder.encode(request.password()))
-                .role(Role.USER)
-                .nickname(request.nickname())
-                .gender(request.gender())
-                .birthdate(request.birthdate())
-                .nationality(request.nationality())
-                .provider(Provider.LOCAL)
-                .build();
-
-        Member savedMember = memberRepository.save(member);
-
-        return new SignUpResponseDto(
-                savedMember.getMemberId(),
-                savedMember.getEmail(),
-                savedMember.getNickname(),
-                savedMember.getRole()
-        );
-    }
 
     @Transactional(readOnly = true)
-    public LoginResponseDto login(LoginRequestDto request) {
-        Member member = memberRepository.findByEmail(request.email())
-                .orElseThrow(()-> new BaseException(MemberErrorCode.INVALID_CREDENTIALS));
+    public ProfileResponseDto getProfile(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        if (!passwordEncoder.matches(request.password(), member.getPassword())) {
-            throw new BaseException(MemberErrorCode.INVALID_CREDENTIALS);
-        }
-
-        String accessToken = jwtUtil.generateAccessToken(
-                member.getMemberId(),
-                member.getEmail(),
-                member.getRole()
-        );
-
-        String refreshToken = jwtUtil.generateRefreshToken(member.getMemberId());
-
-        return new LoginResponseDto(
-                accessToken,
-                refreshToken,
+        return new ProfileResponseDto(
                 member.getMemberId(),
                 member.getEmail(),
                 member.getNickname(),
-                member.getRole()
+                member.getProfileImage(),
+                member.getGender(),
+                member.getBirthdate(),
+                member.getNationality()
         );
     }
-
-    @Transactional(readOnly = true)
-    public SocialLoginResponseDto googleLogin(String code) {
-        // 구글에서 사용자 정보 조회
-        var tokenResponse = googleOAuthService.getAccessToken(code);
-        GoogleUserInfoResponse googleUser = googleOAuthService.getUserInfo(tokenResponse.accessToken());
-
-        // DB에서 회원 확인 (email + provider)
-        Optional<Member> memberOpt = memberRepository
-                .findByEmailAndProvider(googleUser.email(), Provider.GOOGLE);
-
-        if (memberOpt.isPresent()) {
-            // 기존 회원 - 로그인 처리
-            Member member = memberOpt.get();
-
-            String accessToken = jwtUtil.generateAccessToken(
-                    member.getMemberId(),
-                    member.getEmail(),
-                    member.getRole()
-            );
-            String refreshToken = jwtUtil.generateRefreshToken(member.getMemberId());
-
-            LoginResponseDto loginResponse = new LoginResponseDto(
-                    accessToken,
-                    refreshToken,
-                    member.getMemberId(),
-                    member.getEmail(),
-                    member.getNickname(),
-                    member.getRole()
-            );
-
-            return SocialLoginResponseDto.existing(loginResponse);
-        } else {
-            // 신규 회원 - 추가 정보 입력 필요
-            return SocialLoginResponseDto.newMember(googleUser.email());
-        }
-    }
-
 
     @Transactional
-    public LoginResponseDto completeSocialSignUp(SocialSignUpRequestDto request) {
-        // 이미 가입된 회원인지 확인
-        if (memberRepository.findByEmailAndProvider(request.email(), request.provider()).isPresent()) {
-            throw new BaseException(MemberErrorCode.DUPLICATE_EMAIL);
+    public ProfileResponseDto updateProfile(Long memberId, ProfileUpdateRequestDto request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        if (!member.getNickname().equals(request.nickname())) {
+            if (memberRepository.existsByNickname(request.nickname())) {
+                throw new BaseException(MemberErrorCode.DUPLICATE_NICKNAME);
+            }
         }
 
-        // 닉네임 중복 확인
-        if (memberRepository.existsByNickname(request.nickname())) {
-            throw new BaseException(MemberErrorCode.DUPLICATE_NICKNAME);
+        member.updateProfile(request.nickname(), request.gender(), request.birthdate(), request.nationality());
+
+        return new ProfileResponseDto(
+                member.getMemberId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getProfileImage(),
+                member.getGender(),
+                member.getBirthdate(),
+                member.getNationality()
+        );
+    }
+
+    @Transactional
+    public void updatePassword(Long memberId, PasswordUpdateRequestDto request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 소셜 로그인 회원은 비밀번호 변경 불가
+        if (!member.getProvider().equals(Provider.LOCAL)) {
+            throw new BaseException(MemberErrorCode.SOCIAL_MEMBER_CANNOT_CHANGE_PASSWORD);
         }
 
-        Member member = Member.builder()
-                .email(request.email())
-                .provider(request.provider())
-                .nickname(request.nickname())
-                .gender(request.gender())
-                .birthdate(request.birthdate())
-                .nationality(request.nationality())
-                .role(Role.USER)
-                .build();
+        // 현재 비밀번호 확인
+        if (!passwordEncoder.matches(request.currentPassword(), member.getPassword())) {
+            throw new BaseException(MemberErrorCode.INVALID_CURRENT_PASSWORD);
+        }
 
-        Member savedMember = memberRepository.save(member);
+        // 새 비밀번호 확인
+        if (!request.newPassword().equals(request.newPasswordConfirm())) {
+            throw new BaseException(MemberErrorCode.PASSWORD_MISMATCH);
+        }
 
-        String accessToken = jwtUtil.generateAccessToken(
-                savedMember.getMemberId(),
-                savedMember.getEmail(),
-                savedMember.getRole()
-        );
-        String refreshToken = jwtUtil.generateRefreshToken(savedMember.getMemberId());
+        member.updatePassword(passwordEncoder.encode(request.newPassword()));
+    }
 
-        return new LoginResponseDto(
-                accessToken,
-                refreshToken,
-                savedMember.getMemberId(),
-                savedMember.getEmail(),
-                savedMember.getNickname(),
-                savedMember.getRole()
-        );
+    @Transactional
+    public void deleteMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        memberRepository.delete(member);
     }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -2,6 +2,9 @@ server:
   port: 8080
 
 spring:
+  config:
+    import:
+      - optional:file:/etc/secret/application-secret.yaml
   application:
     name: backend-member
   management:
@@ -13,18 +16,17 @@ spring:
       tags:
         application: ${spring.application.name}
   datasource:
-    driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:earseo}
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME:org.postgresql.Driver}
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/earseo}
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:1234}
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
     properties:
       hibernate:
-        show_sql: true
-        format_sql: true
+        show_sql: false
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_schema: member
     open-in-view: false
@@ -36,22 +38,27 @@ oauth:
     redirect-uri: http://localhost:8080/api/member/oauth/google
     token-uri: https://oauth2.googleapis.com/token
     user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
-#  kafka:
-#    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-#    consumer:
-#      group-id: ${KAFKA_CONSUMER_GROUP_ID:${spring.application.name}-group}
-#      auto-offset-reset: earliest
-#      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-#      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-#      properties:
-#        spring:
-#          json:
-#            trusted:
-#              packages: '*'
-#    producer:
-#      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-#      value-serializer: org.apache.kafka.common.serialization.StringSerializer
-#      acks: all
+kafka:
+  bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+  consumer:
+    group-id: ${SPRING_KAFKA_CONSUMER_GROUP_ID:${spring.application.name}-consumer-group}
+    auto-offset-reset: earliest
+    key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+  producer:
+    key-serializer: org.apache.kafka.common.serialization.StringSerializer
+    value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    acks: all
+  properties:
+    security.protocol: ${SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL:PLAINTEXT}
+    sasl.mechanism: ${SPRING_KAFKA_PROPERTIES_SASL_MECHANISM:PLAIN}
+    sasl.jaas.config: ${SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG:}
+  data:
+    redis:
+      password: ${VALKEY_PASSWORD:}
+      sentinel:
+        master: ${SPRING_DATA_REDIS_SENTINEL_MASTER:valkey-master}
+        nodes: ${SPRING_DATA_REDIS_SENTINEL_NODES:localhost:26379}
 
 jwt:
   secret: ${JWT_SECRET}
@@ -71,7 +78,8 @@ springdoc:
 
 logging:
   level:
-    org.hibernate.SQL: debug
-    org.hibernate.type.descriptor.sql.BasicBinder: trace
-#    org.springframework.kafka: info
-#    org.apache.kafka: warn
+    org.hibernate.SQL: ${LOGGING_LEVEL_ORG_HIBERNATE_SQL:debug}
+
+
+member:
+  default-profile-image: ${DEFAULT_PROFILE_IMAGE:C:/uploads/profiles/default-profile.png}


### PR DESCRIPTION
## 🧩 구현/변경 사항
- 마이페이지 회원정보 수정
- 회원 탈퇴
- 로그아웃 - 추후에 블랙리스트 기능 구현 예정
- 프로젝트 yaml 파일 수정

---

## 사용자 시나리오(UML)(옵션)

---

## 🧪 테스트 결과

---

## BREAKING CHANGE (옵션)
- <호환성 깨짐 / API 변경 / 클라이언트 수정 필요 사항>
- (예: `/user/{userId}/alert` → `/user/queue/alert` 변경, timestamp 포맷 KST 필수 등)

---

## 참고
- 기타 후속 작업이나 주의사항
- (예: JWT 인증은 추후 연동 예정, 로깅 레벨은 임시 상향 조정 등)

---

## 🪞 회고 및 개선 아이디어 (옵션)
- 프로필 조회 기능 구현 (추후에 Gateway로 검증 후 헤더에 memberId 전달 (임시로 1L 사용))
- 프로필 수정 기능 구현 (추후에 Gateway로 검증 후 헤더에 memberId 전달 (임시로 1L 사용))
- 프로필 사진 (환경변수로 회원가입 시 기본 이미지로 설정, 추후에 S3 설정과 사진 업로드 및 수정 기능 추가 예정)
- 비밀번호 수정 기능 구현
- MemberService에 너무 많은 로직이 모여서 기존의 회원가입, 로그인 등의 로직은 AuthService로 분리하고 회원 정보 확인 및 수정 등의 로직은 MemberService에 넣었습니다

---

## 💬 리뷰 받고 싶은 부분 (옵션)
- yaml 파일도 노션 참고해서 작성했는데 제대로 작성했는지 검토 부탁드립니다.
- yaml 파일의 이미지 환경변수 부분은 임시로 추가한 부분이라 추후에 S3 연동하면 삭제할 예정입니다.
