### PR TITLE
[#16] 회원가입 시 이메일 인증 기능 구현 (인증번호)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/earseo/member/common/exception/MemberErrorCode.java
+++ b/src/main/java/com/earseo/member/common/exception/MemberErrorCode.java
@@ -15,7 +15,12 @@ public enum MemberErrorCode implements ErrorCodeInterface {
     SOCIAL_MEMBER_CANNOT_CHANGE_PASSWORD("MEM005", "소셜 로그인 회원은 비밀번호를 변경할 수 없습니다.", HttpStatus.BAD_REQUEST),
     INVALID_CURRENT_PASSWORD("MEM006", "현재 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     PASSWORD_MISMATCH("MEM007", "새 비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
-    ALREADY_REGISTERED_WITH_DIFFERENT_PROVIDER("MEM008", "이미 다른 방식으로 가입된 이메일입니다.", HttpStatus.CONFLICT);
+    ALREADY_REGISTERED_WITH_DIFFERENT_PROVIDER("MEM008", "이미 다른 방식으로 가입된 이메일입니다.", HttpStatus.CONFLICT),
+    INVALID_REFRESH_TOKEN("MEM009", "유효하지 않은 Refresh Token입니다.", HttpStatus.UNAUTHORIZED),
+    EMAIL_SEND_FAILED("MEM010", "이메일 발송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_VERIFICATION_CODE("MEM011", "유효하지 않은 인증코드입니다.", HttpStatus.BAD_REQUEST),
+    VERIFICATION_CODE_EXPIRED("MEM012", "인증코드가 만료되었습니다.", HttpStatus.BAD_REQUEST),
+    EMAIL_NOT_VERIFIED("MEM013", "이메일 인증이 완료되지 않았습니다.", HttpStatus.BAD_REQUEST);
 
     private final String status;
     private final String message;

--- a/src/main/java/com/earseo/member/controller/AuthController.java
+++ b/src/main/java/com/earseo/member/controller/AuthController.java
@@ -1,12 +1,8 @@
 package com.earseo.member.controller;
 
 import com.earseo.member.common.BaseResponse;
-import com.earseo.member.dto.request.SocialSignUpRequestDto;
-import com.earseo.member.dto.request.LoginRequestDto;
-import com.earseo.member.dto.request.SignUpRequestDto;
-import com.earseo.member.dto.response.SocialLoginResponseDto;
-import com.earseo.member.dto.response.LoginResponseDto;
-import com.earseo.member.dto.response.SignUpResponseDto;
+import com.earseo.member.dto.request.*;
+import com.earseo.member.dto.response.*;
 import com.earseo.member.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -51,10 +47,39 @@ public class AuthController {
         return ResponseEntity.ok(BaseResponse.ok(response));
     }
 
-    @Operation(summary = "로그아웃", description = "로그아웃")
-    @PostMapping("/logout")
-    public ResponseEntity<BaseResponse<Void>> logout() {
-        authService.logout();
+    @Operation(summary = "닉네임 중복 확인", description = "닉네임 사용 가능 여부 확인")
+    @GetMapping("/nickname/check")
+    public ResponseEntity<BaseResponse<NicknameCheckResponseDto>> checkNickname(
+            @RequestParam("nickname") String nickname
+    ) {
+        NicknameCheckResponseDto response = authService.checkNickname(nickname);
+        return ResponseEntity.ok(BaseResponse.ok(response));
+    }
+
+    @Operation(summary = "토큰 재발급", description = "Refresh Token으로 새 Access Token 발급")
+    @PostMapping("/reissue")
+    public ResponseEntity<BaseResponse<TokenRefreshResponseDto>> reissue(
+            @Valid @RequestBody TokenRefreshRequestDto request
+    ) {
+        TokenRefreshResponseDto response = authService.reissue(request);
+        return ResponseEntity.ok(BaseResponse.ok(response));
+    }
+
+    @Operation(summary = "이메일 인증코드 발송", description = "회원가입용 이메일 인증코드 발송")
+    @PostMapping("/email/send")
+    public ResponseEntity<BaseResponse<Void>> sendVerificationCode(
+            @Valid @RequestBody EmailVerificationRequestDto request
+    ) {
+        authService.sendVerificationCode(request);
+        return ResponseEntity.ok(BaseResponse.ok(null));
+    }
+
+    @Operation(summary = "이메일 인증코드 검증", description = "이메일 인증코드 확인")
+    @PostMapping("/email/verify")
+    public ResponseEntity<BaseResponse<Void>> verifyEmail(
+            @Valid @RequestBody EmailVerificationConfirmDto request
+    ) {
+        authService.verifyEmail(request);
         return ResponseEntity.ok(BaseResponse.ok(null));
     }
 }

--- a/src/main/java/com/earseo/member/controller/MemberController.java
+++ b/src/main/java/com/earseo/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.earseo.member.common.BaseResponse;
 import com.earseo.member.dto.request.PasswordUpdateRequestDto;
 import com.earseo.member.dto.request.ProfileUpdateRequestDto;
 import com.earseo.member.dto.response.ProfileResponseDto;
+import com.earseo.member.service.AuthService;
 import com.earseo.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -16,12 +17,13 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
+    private final AuthService authService;
 
     @Operation(summary = "프로필 조회", description = "현재 로그인한 회원의 프로필 정보 조회")
     @GetMapping("/profile")
-    public ResponseEntity<BaseResponse<ProfileResponseDto>> getProfile() {
-        // 추후에 Gateway로 검증 후 헤더에 memberId 전달 (임시로 1L 사용)
-        Long memberId = 1L;
+    public ResponseEntity<BaseResponse<ProfileResponseDto>> getProfile(
+            @RequestHeader("X-USER-ID") Long memberId
+    ) {
         ProfileResponseDto response = memberService.getProfile(memberId);
         return ResponseEntity.ok(BaseResponse.ok(response));
     }
@@ -29,9 +31,8 @@ public class MemberController {
     @Operation(summary = "프로필 수정", description = "회원 정보 수정 (프로필 사진 제외)")
     @PutMapping("/profile")
     public ResponseEntity<BaseResponse<ProfileResponseDto>> updateProfile(
+            @RequestHeader("X-USER-ID") Long memberId,
             @Valid @RequestBody ProfileUpdateRequestDto request) {
-        // 추후에 Gateway로 검증 후 헤더에 memberId 전달 (임시로 1L 사용)
-        Long memberId = 1L;
         ProfileResponseDto response = memberService.updateProfile(memberId, request);
         return ResponseEntity.ok(BaseResponse.ok(response));
     }
@@ -39,19 +40,27 @@ public class MemberController {
     @Operation(summary = "비밀번호 변경", description = "현재 비밀번호 확인 후 새 비밀번호로 변경")
     @PutMapping("/password")
     public ResponseEntity<BaseResponse<Void>> updatePassword(
+            @RequestHeader("X-USER-ID") Long memberId,
             @Valid @RequestBody PasswordUpdateRequestDto request) {
-        // 추후에 Gateway로 검증 후 헤더에 memberId 전달 (임시로 1L 사용)
-        Long memberId = 1L;
         memberService.updatePassword(memberId, request);
+        return ResponseEntity.ok(BaseResponse.ok(null));
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃 및 Refresh Token 무효화")
+    @PostMapping("/logout")
+    public ResponseEntity<BaseResponse<Void>> logout(
+            @RequestHeader("X-USER-ID") Long memberId
+    ) {
+        authService.logout(memberId);
         return ResponseEntity.ok(BaseResponse.ok(null));
     }
 
 
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 처리")
     @DeleteMapping
-    public ResponseEntity<BaseResponse<Void>> deleteMember() {
-        // 추후에 Gateway로 검증 후 헤더에 memberId 전달 (임시로 1L 사용)
-        Long memberId = 1L;
+    public ResponseEntity<BaseResponse<Void>> deleteMember(
+            @RequestHeader("X-USER-ID") Long memberId
+    ) {
         memberService.deleteMember(memberId);
         return ResponseEntity.ok(BaseResponse.ok(null));
     }

--- a/src/main/java/com/earseo/member/dto/request/EmailVerificationConfirmDto.java
+++ b/src/main/java/com/earseo/member/dto/request/EmailVerificationConfirmDto.java
@@ -1,0 +1,14 @@
+package com.earseo.member.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailVerificationConfirmDto(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "인증코드는 필수입니다.")
+        String code
+) {
+}

--- a/src/main/java/com/earseo/member/dto/request/EmailVerificationRequestDto.java
+++ b/src/main/java/com/earseo/member/dto/request/EmailVerificationRequestDto.java
@@ -1,0 +1,11 @@
+package com.earseo.member.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailVerificationRequestDto(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email
+) {
+}

--- a/src/main/java/com/earseo/member/dto/request/TokenRefreshRequestDto.java
+++ b/src/main/java/com/earseo/member/dto/request/TokenRefreshRequestDto.java
@@ -1,0 +1,9 @@
+package com.earseo.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequestDto(
+        @NotBlank(message = "Refresh Token은 필수입니다.")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/earseo/member/dto/response/NicknameCheckResponseDto.java
+++ b/src/main/java/com/earseo/member/dto/response/NicknameCheckResponseDto.java
@@ -1,0 +1,7 @@
+package com.earseo.member.dto.response;
+
+public record NicknameCheckResponseDto(
+        boolean available,
+        String message
+) {
+}

--- a/src/main/java/com/earseo/member/dto/response/TokenRefreshResponseDto.java
+++ b/src/main/java/com/earseo/member/dto/response/TokenRefreshResponseDto.java
@@ -1,0 +1,7 @@
+package com.earseo.member.dto.response;
+
+public record TokenRefreshResponseDto(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/earseo/member/service/AuthService.java
+++ b/src/main/java/com/earseo/member/service/AuthService.java
@@ -2,13 +2,8 @@ package com.earseo.member.service;
 
 import com.earseo.member.common.exception.BaseException;
 import com.earseo.member.common.exception.MemberErrorCode;
-import com.earseo.member.dto.request.SocialSignUpRequestDto;
-import com.earseo.member.dto.request.LoginRequestDto;
-import com.earseo.member.dto.request.SignUpRequestDto;
-import com.earseo.member.dto.response.SocialLoginResponseDto;
-import com.earseo.member.dto.response.GoogleUserInfoResponse;
-import com.earseo.member.dto.response.LoginResponseDto;
-import com.earseo.member.dto.response.SignUpResponseDto;
+import com.earseo.member.dto.request.*;
+import com.earseo.member.dto.response.*;
 import com.earseo.member.entity.Member;
 import com.earseo.member.entity.Provider;
 import com.earseo.member.entity.Role;
@@ -31,12 +26,20 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     private final GoogleOAuthService googleOAuthService;
+    private final RefreshTokenService refreshTokenService;
+    private final EmailService emailService;
+    private final EmailVerificationService emailVerificationService;
 
     @Value("${member.default-profile-image}")
     private String defaultProfileImage;
 
     @Transactional
     public SignUpResponseDto signup(SignUpRequestDto request) {
+        // 이메일 인증 완료 여부 확인
+        if (!emailVerificationService.isVerified(request.email())) {
+            throw new BaseException(MemberErrorCode.EMAIL_NOT_VERIFIED);
+        }
+
         validateDuplicateMember(request.email(), Provider.LOCAL);
 
         if (memberRepository.existsByNickname(request.nickname())) {
@@ -56,6 +59,9 @@ public class AuthService {
                 .build();
 
         Member savedMember = memberRepository.save(member);
+
+        // 회원가입 완료 후 인증 완료 상태 삭제
+        emailVerificationService.deleteVerified(request.email());
 
         return new SignUpResponseDto(
                 savedMember.getMemberId(),
@@ -81,6 +87,12 @@ public class AuthService {
         );
 
         String refreshToken = jwtUtil.generateRefreshToken(member.getMemberId());
+
+        refreshTokenService.saveRefreshToken(
+                member.getMemberId(),
+                refreshToken,
+                jwtUtil.getRefreshTokenExpiration()
+        );
 
         return new LoginResponseDto(
                 accessToken,
@@ -112,6 +124,12 @@ public class AuthService {
                     member.getRole()
             );
             String refreshToken = jwtUtil.generateRefreshToken(member.getMemberId());
+
+            refreshTokenService.saveRefreshToken(
+                    member.getMemberId(),
+                    refreshToken,
+                    jwtUtil.getRefreshTokenExpiration()
+            );
 
             LoginResponseDto loginResponse = new LoginResponseDto(
                     accessToken,
@@ -160,6 +178,12 @@ public class AuthService {
         );
         String refreshToken = jwtUtil.generateRefreshToken(savedMember.getMemberId());
 
+        refreshTokenService.saveRefreshToken(
+                savedMember.getMemberId(),
+                refreshToken,
+                jwtUtil.getRefreshTokenExpiration()
+        );
+
         return new LoginResponseDto(
                 accessToken,
                 refreshToken,
@@ -170,7 +194,21 @@ public class AuthService {
         );
     }
 
-    public void logout(){}
+    /**
+     * 닉네임 중복 확인
+     */
+    public NicknameCheckResponseDto checkNickname(String nickname) {
+        boolean exists = memberRepository.existsByNickname(nickname);
+
+        if (exists) {
+            return new NicknameCheckResponseDto(false, "이미 사용중인 닉네임입니다.");
+        }
+        return new NicknameCheckResponseDto(true, "사용가능한 닉네임입니다.");
+    }
+
+    public void logout(Long memberId) {
+        refreshTokenService.deleteRefreshToken(memberId);
+    }
 
     private void validateDuplicateMember(String email, Provider provider) {
         // 같은 이메일, 같은 Provider 확인
@@ -183,5 +221,80 @@ public class AuthService {
         if (existingMember.isPresent()) {
             throw new BaseException(MemberErrorCode.ALREADY_REGISTERED_WITH_DIFFERENT_PROVIDER);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public TokenRefreshResponseDto reissue(TokenRefreshRequestDto request) {
+        // Refresh Token에서 memberId 추출
+        Long memberId;
+        try {
+            memberId = jwtUtil.getMemberIdFromToken(request.refreshToken());
+        } catch (Exception e) {
+            throw new BaseException(MemberErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // Redis에 저장된 Refresh Token과 비교
+        if (!refreshTokenService.validateRefreshToken(memberId, request.refreshToken())) {
+            throw new BaseException(MemberErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // Member 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 새 토큰 발급
+        String newAccessToken = jwtUtil.generateAccessToken(
+                member.getMemberId(),
+                member.getEmail(),
+                member.getRole()
+        );
+        String newRefreshToken = jwtUtil.generateRefreshToken(member.getMemberId());
+
+        // 새 Refresh Token Redis 저장 (기존 토큰 덮어쓰기)
+        refreshTokenService.saveRefreshToken(
+                member.getMemberId(),
+                newRefreshToken,
+                jwtUtil.getRefreshTokenExpiration()
+        );
+
+        return new TokenRefreshResponseDto(newAccessToken, newRefreshToken);
+    }
+
+    /**
+     * 이메일 인증코드 발송
+     */
+    public void sendVerificationCode(EmailVerificationRequestDto request) {
+        // 이미 가입된 이메일인지 확인
+        if (memberRepository.findByEmailAndProvider(request.email(), Provider.LOCAL).isPresent()) {
+            throw new BaseException(MemberErrorCode.DUPLICATE_EMAIL);
+        }
+
+        // 다른 Provider로 가입된 이메일인지 확인
+        if (memberRepository.findByEmail(request.email()).isPresent()) {
+            throw new BaseException(MemberErrorCode.ALREADY_REGISTERED_WITH_DIFFERENT_PROVIDER);
+        }
+
+        String code = emailVerificationService.generateCode();
+        emailVerificationService.saveCode(request.email(), code);
+        emailService.sendVerificationCode(request.email(), code);
+    }
+
+    /**
+     * 이메일 인증코드 검증
+     */
+    public void verifyEmail(EmailVerificationConfirmDto request) {
+        if (!emailVerificationService.hasCode(request.email())) {
+            throw new BaseException(MemberErrorCode.VERIFICATION_CODE_EXPIRED);
+        }
+
+        if (!emailVerificationService.verifyCode(request.email(), request.code())) {
+            throw new BaseException(MemberErrorCode.INVALID_VERIFICATION_CODE);
+        }
+
+        // 인증 성공 시 인증 완료 상태 저장
+        emailVerificationService.saveVerified(request.email());
+
+        // 인증코드 삭제
+        emailVerificationService.deleteCode(request.email());
     }
 }

--- a/src/main/java/com/earseo/member/service/EmailService.java
+++ b/src/main/java/com/earseo/member/service/EmailService.java
@@ -1,0 +1,55 @@
+package com.earseo.member.service;
+
+import com.earseo.member.common.exception.BaseException;
+import com.earseo.member.common.exception.MemberErrorCode;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    public void sendVerificationCode(String to, String code) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setFrom(fromEmail);
+            helper.setTo(to);
+            helper.setSubject("[EarSEO] 이메일 인증코드");
+            helper.setText(buildEmailContent(code), true);
+
+            mailSender.send(message);
+            log.info("인증코드 이메일 발송 완료 - to: {}", to);
+        } catch (MessagingException e) {
+            log.error("이메일 발송 실패 - to: {}", to, e);
+            throw new BaseException(MemberErrorCode.EMAIL_SEND_FAILED);
+        }
+    }
+
+    private String buildEmailContent(String code) {
+        return """
+                <div style="max-width: 500px; margin: 0 auto; padding: 20px; font-family: Arial, sans-serif;">
+                    <h2 style="color: #333;">이메일 인증</h2>
+                    <p>안녕하세요, EarSEO입니다.</p>
+                    <p>아래 인증코드를 입력해주세요.</p>
+                    <div style="background-color: #f4f4f4; padding: 15px; text-align: center; margin: 20px 0;">
+                        <span style="font-size: 24px; font-weight: bold; letter-spacing: 3px;">%s</span>
+                    </div>
+                    <p style="color: #666; font-size: 14px;">인증코드는 5분간 유효합니다.</p>
+                </div>
+                """.formatted(code);
+    }
+}

--- a/src/main/java/com/earseo/member/service/EmailVerificationService.java
+++ b/src/main/java/com/earseo/member/service/EmailVerificationService.java
@@ -1,0 +1,104 @@
+package com.earseo.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+
+    private final RedisTemplate<String, String> stringTemplate;
+
+    private static final String VERIFICATION_PREFIX = "email:verification:";
+    private static final String VERIFIED_PREFIX = "email:verified:";
+    private static final long EXPIRATION_MINUTES = 5;
+    private static final long VERIFIED_EXPIRATION_MINUTES = 10;
+
+    /**
+     * 6자리 인증코드 생성
+     */
+    public String generateCode() {
+        SecureRandom random = new SecureRandom();
+        int code = 100000 + random.nextInt(900000);
+        return String.valueOf(code);
+    }
+
+    /**
+     * 인증코드 저장
+     */
+    public void saveCode(String email, String code) {
+        String key = VERIFICATION_PREFIX + email;
+        stringTemplate.opsForValue().set(key, code, EXPIRATION_MINUTES, TimeUnit.MINUTES);
+        log.info("인증코드 저장 완료 - email: {}", email);
+    }
+
+    /**
+     * 인증코드 검증
+     */
+    public boolean verifyCode(String email, String code) {
+        String key = VERIFICATION_PREFIX + email;
+        String storedCode = stringTemplate.opsForValue().get(key);
+
+        if (storedCode == null) {
+            log.warn("인증코드 없음 또는 만료 - email: {}", email);
+            return false;
+        }
+
+        if (storedCode.equals(code)) {
+            log.info("인증코드 검증 성공 - email: {}", email);
+            return true;
+        }
+
+        log.warn("인증코드 불일치 - email: {}", email);
+        return false;
+    }
+
+    /**
+     * 인증코드 삭제 (인증 성공 후 호출)
+     */
+    public void deleteCode(String email) {
+        String key = VERIFICATION_PREFIX + email;
+        stringTemplate.delete(key);
+        log.info("인증코드 삭제 완료 - email: {}", email);
+    }
+
+    /**
+     * 인증코드 존재 여부 확인
+     */
+    public boolean hasCode(String email) {
+        String key = VERIFICATION_PREFIX + email;
+        return Boolean.TRUE.equals(stringTemplate.hasKey(key));
+    }
+
+    /**
+     * 인증 완료 상태 저장
+     */
+    public void saveVerified(String email) {
+        String key = VERIFIED_PREFIX + email;
+        stringTemplate.opsForValue().set(key, "true", VERIFIED_EXPIRATION_MINUTES, TimeUnit.MINUTES);
+        log.info("이메일 인증 완료 상태 저장 - email: {}", email);
+    }
+
+    /**
+     * 인증 완료 여부 확인
+     */
+    public boolean isVerified(String email) {
+        String key = VERIFIED_PREFIX + email;
+        return Boolean.TRUE.equals(stringTemplate.hasKey(key));
+    }
+
+    /**
+     * 인증 완료 상태 삭제 (회원가입 완료 후 호출)
+     */
+    public void deleteVerified(String email) {
+        String key = VERIFIED_PREFIX + email;
+        stringTemplate.delete(key);
+        log.info("이메일 인증 완료 상태 삭제 - email: {}", email);
+    }
+}

--- a/src/main/java/com/earseo/member/service/RefreshTokenService.java
+++ b/src/main/java/com/earseo/member/service/RefreshTokenService.java
@@ -1,0 +1,64 @@
+package com.earseo.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RedisTemplate<String, String> stringTemplate;
+
+    private static final String REFRESH_TOKEN_PREFIX = "refresh:";
+
+    /**
+     * Refresh Token 저장
+     */
+    public void saveRefreshToken(Long memberId, String refreshToken, long expirationMs) {
+        String key = REFRESH_TOKEN_PREFIX + memberId;
+        stringTemplate.opsForValue().set(key, refreshToken, expirationMs, TimeUnit.MILLISECONDS);
+        log.info("Refresh Token 저장 완료 - memberId: {}", memberId);
+    }
+
+    /**
+     * Refresh Token 조회
+     */
+    public String getRefreshToken(Long memberId) {
+        String key = REFRESH_TOKEN_PREFIX + memberId;
+        return stringTemplate.opsForValue().get(key);
+    }
+
+    /**
+     * Refresh Token 존재 여부 확인
+     */
+    public boolean hasRefreshToken(Long memberId) {
+        String key = REFRESH_TOKEN_PREFIX + memberId;
+        return Boolean.TRUE.equals(stringTemplate.hasKey(key));
+    }
+
+    /**
+     * Refresh Token 삭제 (로그아웃 시 호출)
+     */
+    public void deleteRefreshToken(Long memberId) {
+        String key = REFRESH_TOKEN_PREFIX + memberId;
+        Boolean deleted = stringTemplate.delete(key);
+        if (Boolean.TRUE.equals(deleted)) {
+            log.info("Refresh Token 삭제 완료 - memberId: {}", memberId);
+        } else {
+            log.warn("Refresh Token 삭제 실패 또는 존재하지 않음 - memberId: {}", memberId);
+        }
+    }
+
+    /**
+     * Refresh Token 검증 (저장된 값과 일치하는지 확인)
+     */
+    public boolean validateRefreshToken(Long memberId, String refreshToken) {
+        String storedToken = getRefreshToken(memberId);
+        return storedToken != null && storedToken.equals(refreshToken);
+    }
+}

--- a/src/main/java/com/earseo/member/util/JwtUtil.java
+++ b/src/main/java/com/earseo/member/util/JwtUtil.java
@@ -59,4 +59,45 @@ public class JwtUtil {
                 .signWith(secretKey)
                 .compact();
     }
+    /**
+     * 토큰에서 Claims 추출
+     */
+    public Claims parseToken(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    /**
+     * 토큰에서 memberId 추출
+     */
+    public Long getMemberIdFromToken(String token) {
+        Claims claims = parseToken(token);
+        return Long.parseLong(claims.getSubject());
+    }
+
+    /**
+     * 토큰 만료시간 추출 (Redis TTL 설정용)
+     */
+    public long getExpiration(String token) {
+        Claims claims = parseToken(token);
+        return claims.getExpiration().getTime();
+    }
+
+    /**
+     * 토큰 남은 유효시간 계산 (밀리초)
+     */
+    public long getRemainingTime(String token) {
+        long expiration = getExpiration(token);
+        return expiration - System.currentTimeMillis();
+    }
+
+    /**
+     * Refresh Token 만료시간 반환 (밀리초)
+     */
+    public long getRefreshTokenExpiration() {
+        return refreshTokenExpiration;
+    }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -19,6 +19,25 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
+  data:
+    redis:
+      password: ${VALKEY_PASSWORD:valkeypass}
+      sentinel:
+        master: ${SPRING_DATA_REDIS_SENTINEL_MASTER:valkey-master}
+        nodes: ${SPRING_DATA_REDIS_SENTINEL_NODES:localhost:26379,localhost:26380,localhost:26381}
+      database: 3
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GMAIL_USERNAME}
+    password: ${GMAIL_APP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
 
 oauth:
   google:
@@ -54,13 +73,6 @@ oauth:
         spring.json.add.type.headers: false
     properties:
       security.protocol: ${SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL:PLAINTEXT}
-  data:
-    redis:
-      password: ${VALKEY_PASSWORD:valkeypass}
-      sentinel:
-        master: ${SPRING_DATA_REDIS_SENTINEL_MASTER:valkey-master}
-        nodes: ${SPRING_DATA_REDIS_SENTINEL_NODES:localhost:26379,localhost:26380,localhost:26381}
-      database: 3
 
 management:
   endpoints:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -26,18 +26,7 @@ spring:
         master: ${SPRING_DATA_REDIS_SENTINEL_MASTER:valkey-master}
         nodes: ${SPRING_DATA_REDIS_SENTINEL_NODES:localhost:26379,localhost:26380,localhost:26381}
       database: 3
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${GMAIL_USERNAME}
-    password: ${GMAIL_APP_PASSWORD}
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
-            required: true
+
 
 oauth:
   google:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,6 +4,19 @@ spring:
   application:
     name: backend-member
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GMAIL_USERNAME:username}
+    password: ${GMAIL_APP_PASSWORD:password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+
 springdoc:
   api-docs:
     enabled: true


### PR DESCRIPTION
## 🧩 구현/변경 사항
- 게이트웨이 x-user-id 설정
- 로그아웃 토큰 만료 방식으로 구현
- 메일 SMTP 설정 (구글)
- 회원 가입 시 이메일 인증 (인증번호 입력) 및 닉네임 중복 기능 추가

[Redis 사용 현황]
Refresh Token 저장
Key: refresh:{memberId}
TTL: 14일
용도: 로그인 시 저장, 로그아웃 시 삭제, 토큰 재발급 시 검증/갱신

이메일 인증코드
Key: email:verification:{email}
TTL: 5분
용도: 인증코드 발송 시 저장, 검증 성공 시 삭제

이메일 인증 완료 상태
Key: email:verified:{email}
TTL: 10분
용도: 인증 검증 성공 시 저장, 회원가입 완료 시 삭제

로그인/로그아웃
로그인 → Redis에 Refresh Token 저장
로그아웃 → Redis에서 Refresh Token 삭제
토큰 재발급 → Redis에서 Refresh Token 검증 후 새 토큰으로 교체

이메일 인증
인증코드 발송 → Redis에 인증코드 저장 (5분)
인증코드 검증 → Redis에서 코드 확인 → 성공 시 인증 완료 상태 저장 (10분)
회원가입 → Redis에서 인증 완료 상태 확인 → 성공 시 삭제

---

## 사용자 시나리오(UML)

---

## 🧪 테스트 결과
<img width="1662" height="465" alt="image" src="https://github.com/user-attachments/assets/181b33c2-defc-4955-874c-729da2fdf302" />


---

## BREAKING CHANGE (옵션)
- <호환성 깨짐 / API 변경 / 클라이언트 수정 필요 사항>
- (예: `/user/{userId}/alert` → `/user/queue/alert` 변경, timestamp 포맷 KST 필수 등)

---

## 참고
- 기타 후속 작업이나 주의사항
- (예: JWT 인증은 추후 연동 예정, 로깅 레벨은 임시 상향 조정 등)

---

## 🪞 회고 및 개선 아이디어 (옵션)

---

## 💬 리뷰 받고 싶은 부분 (옵션)

